### PR TITLE
React18: use createRoot().render() instead of render()

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,14 +1,15 @@
 import React from "react";
-import ReactDOM from "react-dom";
-import "./index.css";
+import { createRoot } from "react-dom/client";
 import reportWebVitals from "./reportWebVitals";
 import App from "./web/App";
+import "./index.css";
 
-ReactDOM.render(
+const container = document.getElementById("root");
+const root = createRoot(container!);
+root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
-  document.getElementById("root")
+  </React.StrictMode>
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/src/web/layout/Nav.test.tsx
+++ b/src/web/layout/Nav.test.tsx
@@ -1,9 +1,9 @@
-import { render, screen } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { TopBar } from "./Nav";
 import LocalPizzaIcon from "@mui/icons-material/LocalPizza";
 
 test("renders title", () => {
-  render(
+  const { getByText } = render(
     <TopBar
       appTitle={
         <>
@@ -19,6 +19,5 @@ test("renders title", () => {
   // you can provide a function for your text matcher to make your matcher more flexible.
   //  const text = screen.getByText(/this is the app title/i);
   // ... and I can't be arsed figuring out how to do that for the above, yet I want to keep appTitle as a node, so
-  const text = screen.getByText(/this is the app/i);
-  expect(text).toBeInTheDocument();
+  expect(getByText(/this is the app/i)).toBeInTheDocument();
 });


### PR DESCRIPTION
* Also use the recommended @testing-library approach for tests
* ... eventhough that currently yields a warning