### PR TITLE
Revert "Renovate: add grouping for uuid"

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -58,10 +58,6 @@
       matchPackageNames: ["@types/jest", "jest"],
     },
     {
-      groupName: "uuid",
-      matchPackageNames: ["@types/uuid", "uuid"],
-    },
-    {
       groupName: "react",
       matchPackageNames: [
         "@types/react",


### PR DESCRIPTION
* No need for this since uuid@11 has native types

This reverts commit d6de7e419e6169f460c724296392821f4af43eb0.